### PR TITLE
0.0.x: Make async container type use backing java stream type for com…

### DIFF
--- a/funcify-kotlin-core/src/main/kotlin/funcify/container/async/Async.kt
+++ b/funcify-kotlin-core/src/main/kotlin/funcify/container/async/Async.kt
@@ -11,9 +11,12 @@ import funcify.container.async.AsyncFactory.DeferredValue.FluxValue
 import funcify.container.attempt.Try
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
 import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
+import java.util.concurrent.Executor
+import java.util.stream.Collectors
 import java.util.stream.Stream
 import kotlin.streams.asSequence
 import kotlin.streams.asStream
@@ -28,76 +31,173 @@ interface Async<out V> : Iterable<V> {
 
     companion object {
 
-        fun <V> of(value: V): Async<V> {
-            return AsyncFactory.AsyncCompletedSuccess<V>(value)
+        fun <V> succeeded(valueStream: Stream<V>): Async<V> {
+            return AsyncFactory.AsyncCompletedSuccess<V>(valueStream)
         }
 
-        fun <V> ofError(throwable: Throwable): Async<V> {
+        fun <V> errored(throwable: Throwable): Async<V> {
             return AsyncFactory.AsyncCompletedFailure<V>(throwable)
         }
 
-        fun <V> ofDeferred(deferredValue: DeferredValue<V>): Async<V> {
+        fun <V> deferred(deferredValue: DeferredValue<V>): Async<V> {
             return AsyncFactory.AsyncDeferredValue<V>(deferredValue)
         }
 
-        fun <V> empty(): Async<V> {
-            return ofDeferred(FluxValue<V>(Flux.empty()))
+        fun <V> succeededSingle(value: V): Async<V> {
+            return succeeded(Stream.of(value))
         }
 
-        fun <V> fromCompletionStage(completionStage: CompletionStage<V>): Async<V> {
+        fun <V> empty(): Async<V> {
+            return succeeded(Stream.empty())
+        }
+
+        fun <V> deferFromSupplier(executor: Executor, supplier: () -> V): Async<V> {
+            return fromSingleValueCompletionStage(CompletableFuture.supplyAsync({ supplier.invoke() }, executor))
+        }
+
+        fun <V> deferFromStream(executor: Executor, supplier: () -> Stream<V>): Async<V> {
+            return fromFlux(Flux.fromStream { supplier.invoke() }
+                                    .subscribeOn(Schedulers.fromExecutor(executor)))
+        }
+
+        fun <V> deferFromIterable(executor: Executor, iterable: Iterable<V>): Async<V> {
+            return fromFlux(Flux.fromIterable(iterable)
+                                    .subscribeOn(Schedulers.fromExecutor(executor)))
+        }
+
+        fun <V> deferFromSequence(executor: Executor, sequence: Sequence<V>): Async<V> {
+            return deferFromIterable(executor, sequence.asIterable())
+        }
+
+        fun <V> fromAttempt(attempt: Try<V>): Async<V> {
+            return attempt.fold({ v: V ->
+                                    succeededSingle(v)
+                                }, { throwable: Throwable ->
+                                    errored(throwable)
+                                })
+        }
+
+        fun <V> fromStreamAttempt(attempt: Try<Stream<V>>): Async<V> {
+            return attempt.fold({ v: Stream<V> ->
+                                    succeeded(v)
+                                }, { throwable: Throwable ->
+                                    errored(throwable)
+                                })
+        }
+
+        fun <V> fromStreamOfAttempts(attemptStream: Stream<Try<V>>): Async<V> {
+            return fromFlux(Flux.fromStream(attemptStream)
+                                    .flatMap { attempt -> attempt.fold({ v -> Flux.just(v) }, { thr -> Flux.error(thr) }) })
+        }
+
+        fun <V> fromSingleValueCompletionStage(completionStage: CompletionStage<V>): Async<V> {
             return when {
                 completionStage.toCompletableFuture().isCompletedExceptionally -> {
                     Try.attemptNullable(completionStage.toCompletableFuture()::join)
                             .getFailure()
-                            .map { e -> ofError<V>(e) }
-                            .getOrElse { ofError<V>(IllegalArgumentException("completion_stage output is missing exception despite completing exceptionally")) }
+                            .map { e -> errored<V>(e) }
+                            .getOrElse { errored<V>(IllegalArgumentException("completion_stage output is missing exception despite completing exceptionally")) }
                 }
                 completionStage.toCompletableFuture().isDone -> {
                     Try.attempt(completionStage.toCompletableFuture()::join)
                             .getSuccess()
-                            .map { v -> of<V>(v) }
-                            .getOrElse { ofError<V>(IllegalArgumentException("completion_stage output is missing successful result value despite not completing exceptionally")) }
+                            .map { v -> succeededSingle<V>(v) }
+                            .getOrElse { errored<V>(IllegalArgumentException("completion_stage output is missing successful result value despite not completing exceptionally")) }
                 }
                 else -> {
-                    ofDeferred(CompletionStageValue<V>(completionStage))
+                    deferred(CompletionStageValue<V>(completionStage.thenApply { v -> Stream.of(v) }))
                 }
             }
         }
 
-        fun <V> fromNullableCompletionStageValue(completionStage: CompletionStage<V?>): Async<V> {
+        fun <V> fromCompletionStage(completionStage: CompletionStage<Stream<V>>): Async<V> {
+            return when {
+                completionStage.toCompletableFuture().isCompletedExceptionally -> {
+                    Try.attemptNullable(completionStage.toCompletableFuture()::join)
+                            .getFailure()
+                            .map { e -> errored<V>(e) }
+                            .getOrElse { errored<V>(IllegalArgumentException("completion_stage output is missing exception despite completing exceptionally")) }
+                }
+                completionStage.toCompletableFuture().isDone -> {
+                    Try.attempt(completionStage.toCompletableFuture()::join)
+                            .getSuccess()
+                            .map { vStream -> succeeded<V>(vStream) }
+                            .getOrElse { errored<V>(IllegalArgumentException("completion_stage output is missing successful result value despite not completing exceptionally")) }
+                }
+                else -> {
+                    deferred(CompletionStageValue<V>(completionStage.thenApply { stream -> stream }))
+                }
+            }
+        }
+
+        fun <V> fromNullableValuesStreamCompletionStage(completionStage: CompletionStage<Stream<V?>>): Async<V> {
+            return when {
+                completionStage.toCompletableFuture().isCompletedExceptionally -> {
+                    Try.attemptNullable(completionStage.toCompletableFuture()::join)
+                            .getFailure()
+                            .map { e -> errored<V>(e) }
+                            .getOrElse { errored<V>(IllegalArgumentException("completion_stage output is missing exception despite completing exceptionally")) }
+                }
+                completionStage.toCompletableFuture().isDone -> {
+                    Try.attempt(completionStage.toCompletableFuture()::join)
+                            .getSuccess()
+                            .map { vStream ->
+                                succeeded<V>(vStream.flatMap { v ->
+                                    v.toOption()
+                                            .fold({ Stream.empty() }, { nonNullV -> Stream.of(nonNullV) })
+                                })
+                            }
+                            .getOrElse { errored<V>(IllegalArgumentException("completion_stage output is missing successful result value despite not completing exceptionally")) }
+                }
+                else -> {
+                    deferred(CompletionStageValue<V>(completionStage.thenApply { stream ->
+                        stream.flatMap { v ->
+                            v.toOption()
+                                    .fold({ Stream.empty() }, { nonNullV -> Stream.of(nonNullV) })
+                        }
+                    }))
+                }
+            }
+        }
+
+        fun <V> fromNullableSingleValueCompletionStage(completionStage: CompletionStage<V?>): Async<V> {
             return when {
                 completionStage.toCompletableFuture().isCompletedExceptionally -> {
                     Try.attemptNullable(completionStage.toCompletableFuture()::get)
                             .getFailure()
-                            .map { e -> ofError<V>(e) }
-                            .getOrElse { ofError<V>(IllegalArgumentException("completion_stage input is missing exception despite completing exceptionally")) }
+                            .map { e -> errored<V>(e) }
+                            .getOrElse { errored<V>(IllegalArgumentException("completion_stage input is missing exception despite completing exceptionally")) }
                 }
                 completionStage.toCompletableFuture().isDone -> {
                     Try.attemptNullable(completionStage.toCompletableFuture()::get)
                             .getSuccess()
-                            .map { vOpt -> vOpt.fold({ ofError<V>(NoSuchElementException("completed_value is null or not present")) }) { v -> of<V>(v) } }
-                            .getOrElse { ofError<V>(IllegalArgumentException("completion_stage input is missing successful result value despite completing unexceptionally")) }
+                            .map { vOpt ->
+                                vOpt.fold({ succeeded<V>(Stream.empty()) }) { v ->
+                                    succeededSingle<V>(v)
+                                }
+                            }
+                            .getOrElse { errored<V>(IllegalArgumentException("completion_stage input is missing successful result value despite completing unexceptionally")) }
                 }
                 else -> {
-                    ofDeferred(CompletionStageValue<V>(completionStage.thenCompose { v ->
+                    deferred(CompletionStageValue<V>(completionStage.thenCompose { v ->
                         v.toOption()
                                 .fold({
-                                          CompletableFuture<V>().apply { completeExceptionally(IllegalArgumentException("completed_value is null or not present")) }
-                                      }) { value ->
-                                    CompletableFuture.completedFuture(value)
-                                }
+                                          CompletableFuture.completedFuture(Stream.empty())
+                                      }, { value ->
+                                          CompletableFuture.completedFuture(Stream.of(value))
+                                      })
                     }))
                 }
             }
         }
 
         fun <V> fromFlux(fluxValue: Flux<V>): Async<V> {
-            return ofDeferred(FluxValue<V>(fluxValue))
+            return deferred(FluxValue<V>(fluxValue))
         }
 
         fun <V> fromNullableFluxValue(fluxValue: Flux<V?>): Async<V> {
-            return ofDeferred(FluxValue<V>(fluxValue.filter { v -> v != null }
-                                                   .map { v -> v!! }))
+            return deferred(FluxValue<V>(fluxValue.filter { v -> v != null }
+                                                 .map { v -> v!! }))
         }
 
     }
@@ -121,19 +221,22 @@ interface Async<out V> : Iterable<V> {
      * Blocking method
      */
     fun sequence(): Sequence<V> {
-        return fold({ v ->
-                        sequenceOf(v)
-                    }, { thr ->
+        return fold({ vStream ->
+                        vStream.asSequence()
+                    }, {
                         emptySequence()
                     }, { defVal ->
                         when (defVal) {
                             is CompletionStageValue -> {
-                                Try.attempt(defVal.inputStage.toCompletableFuture()::join)
-                                        .sequence()
+                                Try.attempt(defVal.inputStreamStage.toCompletableFuture()::join)
+                                        .map { stream -> stream.asSequence() }
+                                        .fold({ seq -> seq }, { emptySequence() })
+                                        .map { v -> v }
                             }
                             is FluxValue -> {
-                                defVal.inputFlux.toStream()
-                                        .asSequence()
+                                Try.attempt(defVal.inputFlux::toStream)
+                                        .sequence()
+                                        .flatMap { stream -> stream.asSequence() }
                             }
                         }
                     })
@@ -141,14 +244,14 @@ interface Async<out V> : Iterable<V> {
 
 
     fun <R> map(function: (V) -> R): Async<R> {
-        return fold({ v: V ->
-                        of<R>(function.invoke(v))
+        return fold({ vStream ->
+                        fromStreamAttempt(Try.attempt { vStream.map(function::invoke) })
                     }, { throwable: Throwable ->
-                        ofError<R>(throwable)
+                        errored<R>(throwable)
                     }, { deferredValue: DeferredValue<V> ->
                         when (deferredValue) {
                             is CompletionStageValue -> {
-                                fromCompletionStage<R>(deferredValue.inputStage.thenApply(function::invoke))
+                                fromCompletionStage<R>(deferredValue.inputStreamStage.thenApply { stream -> stream.map(function::invoke) })
                             }
                             is FluxValue -> {
                                 fromFlux<R>(deferredValue.inputFlux.map(function::invoke))
@@ -157,137 +260,118 @@ interface Async<out V> : Iterable<V> {
                     })
     }
 
-    fun <R> flatMapSingle(function: (V) -> Async<R>): Async<R> {
-        return fold({ v: V ->
-                        function.invoke(v)
+    fun <R> map(executor: Executor, function: (V) -> R): Async<R> {
+        return fold({ vStream ->
+                        fromCompletionStage(CompletableFuture.supplyAsync({ vStream.map(function::invoke) }, executor))
                     }, { throwable: Throwable ->
-                        ofError<R>(throwable)
+                        errored<R>(throwable)
                     }, { deferredValue: DeferredValue<V> ->
                         when (deferredValue) {
                             is CompletionStageValue -> {
-                                fromCompletionStage<R>(deferredValue.inputStage.thenCompose { v ->
-                                    function.invoke(v)
-                                            .fold({ r ->
-                                                      CompletableFuture.completedFuture(r)
-                                                  }, { thr ->
-                                                      val future: CompletableFuture<R> = CompletableFuture()
-                                                      future.completeExceptionally(thr)
-                                                      future
-                                                  }, { defVal ->
-                                                      when (defVal) {
-                                                          is CompletionStageValue -> defVal.inputStage
-                                                          is FluxValue -> defVal.inputFlux.next()
-                                                                  .toFuture() as CompletionStage<R>
-                                                      }
-                                                  })
+                                fromCompletionStage<R>(deferredValue.inputStreamStage.thenApplyAsync({ vStream -> vStream.map(function::invoke) },
+                                                                                                     executor))
+                            }
+                            is FluxValue -> {
+                                fromFlux<R>(deferredValue.inputFlux.publishOn(Schedulers.fromExecutor(executor))
+                                                    .map(function::invoke))
+                            }
+                        }
+                    })
+    }
+
+    fun <R> flatMap(function: (V) -> Async<R>): Async<R> {
+        return fold({ vStream ->
+                        Try.fromOptional(vStream.map { v -> function.invoke(v) }
+                                                 .map { asyncV ->
+                                                     asyncV.toFlux()
+                                                             .map { r -> r }
+                                                 }
+                                                 .reduce { f1: Flux<R>, f2: Flux<R> -> f1.concatWith(f2) })
+                                .fold({ sFlux -> fromFlux(sFlux) }, { thr -> errored(thr) })
+                    }, { throwable: Throwable ->
+                        errored<R>(throwable)
+                    }, { deferredValue: DeferredValue<V> ->
+                        when (deferredValue) {
+                            is CompletionStageValue -> {
+                                fromCompletionStage<R>(deferredValue.inputStreamStage.thenCompose { vStream ->
+                                    vStream.map(function::invoke)
+                                            .map { asyncV -> asyncV.toCompletionStage() }
+                                            .reduce { streamStage1, streamStage2 ->
+                                                streamStage1.thenCombine(streamStage2) { s1, s2 ->
+                                                    Stream.concat(s1, s2)
+                                                }
+                                            }
+                                            .orElseGet { CompletableFuture.completedFuture(Stream.empty()) }
+                                            .thenApply { s -> s.map { r -> r } }
                                 })
                             }
                             is FluxValue -> {
                                 fromFlux<R>(deferredValue.inputFlux.flatMap { v ->
                                     function.invoke(v)
-                                            .fold({ r ->
-                                                      Mono.just(r)
-                                                              .flux()
-                                                  }, { thr -> Flux.error(thr) }, { defVal ->
-                                                      when (defVal) {
-                                                          is CompletionStageValue -> Mono.fromCompletionStage(defVal.inputStage)
-                                                                  .flux()
-                                                          is FluxValue -> defVal.inputFlux
-                                                      }
-                                                  })
+                                            .toFlux()
+                                            .map { r -> r }
                                 })
                             }
                         }
                     })
     }
 
-    fun <R> flatMapMany(function: (V) -> Stream<Async<R>>): Async<R> {
-        return fold({ v: V ->
-                        fromFlux(function.invoke(v)
-                                         .map { asyncInst ->
-                                             asyncInst.fold({ r ->
-                                                                Mono.just(r)
-                                                                        .flux()
-                                                            }, { thr ->
-                                                                Mono.error<R>(thr)
-                                                                        .flux()
-                                                            }, { defVal ->
-                                                                when (defVal) {
-                                                                    is CompletionStageValue -> Mono.fromCompletionStage(defVal.inputStage)
-                                                                            .flux()
-                                                                    is FluxValue -> defVal.inputFlux
-                                                                }
-                                                            })
-                                         }
-                                         .reduce { f1, f2 -> f1.concatWith(f2) }
-                                         .orElseGet { Flux.empty<R>() })
-
+    fun <R> flatMap(executor: Executor, function: (V) -> Async<R>): Async<R> {
+        return fold({ vStream ->
+                        fromFlux(Flux.fromStream(vStream)
+                                         .publishOn(Schedulers.fromExecutor(executor))
+                                         .map { v -> function.invoke(v) }
+                                         .flatMap { asyncV ->
+                                             asyncV.toFlux()
+                                         })
                     }, { throwable: Throwable ->
-                        ofError<R>(throwable)
+                        errored<R>(throwable)
                     }, { deferredValue: DeferredValue<V> ->
                         when (deferredValue) {
                             is CompletionStageValue -> {
-                                fromFlux<R>(Mono.fromCompletionStage(deferredValue.inputStage.thenApply { v ->
-                                    function.invoke(v)
-                                            .map { asInst ->
-                                                asInst.fold({ r ->
-                                                                Mono.just(r)
-                                                                        .flux()
-                                                            }, { thr ->
-                                                                Flux.error(thr)
-                                                            }, { defVal ->
-                                                                when (defVal) {
-                                                                    is CompletionStageValue -> Mono.fromCompletionStage(defVal.inputStage)
-                                                                            .flux()
-                                                                    is FluxValue -> defVal.inputFlux
-                                                                }
-                                                            })
-                                            }
-                                            .reduce { f1, f2 -> f1.concatWith(f2) }
-                                            .orElseGet { Flux.empty<R>() }
-                                })
-                                                    .flatMapMany { flx -> flx })
+                                fromCompletionStage<R>(deferredValue.inputStreamStage.thenComposeAsync({ vStream ->
+                                                                                                           vStream.map(function::invoke)
+                                                                                                                   .map { asyncV -> asyncV.toCompletionStage() }
+                                                                                                                   .reduce { streamStage1, streamStage2 ->
+                                                                                                                       streamStage1.thenCombine(
+                                                                                                                               streamStage2) { s1, s2 ->
+                                                                                                                           Stream.concat(s1, s2)
+                                                                                                                       }
+                                                                                                                   }
+                                                                                                                   .orElseGet {
+                                                                                                                       CompletableFuture.completedFuture(
+                                                                                                                               Stream.empty())
+                                                                                                                   }
+                                                                                                                   .thenApply { s -> s.map { r -> r } }
+                                                                                                       }, executor))
                             }
                             is FluxValue -> {
-                                fromFlux<R>(deferredValue.inputFlux.map { v ->
+                                fromFlux<R>(deferredValue.inputFlux.flatMap { v ->
                                     function.invoke(v)
-                                            .map { asInst ->
-                                                asInst.fold({ r ->
-                                                                Mono.just(r)
-                                                                        .flux()
-                                                            }, { thr ->
-                                                                Flux.error(thr)
-                                                            }, { defVal ->
-                                                                when (defVal) {
-                                                                    is CompletionStageValue -> Mono.fromCompletionStage(defVal.inputStage)
-                                                                            .flux()
-                                                                    is FluxValue -> defVal.inputFlux
-                                                                }
-                                                            })
-                                            }
-                                            .reduce { f1, f2 -> f1.concatWith(f2) }
-                                            .orElseGet { Flux.empty<R>() }
-                                }
-                                                    .flatMap { flx -> flx })
-
+                                            .toFlux()
+                                            .map { r -> r }
+                                })
                             }
-
                         }
                     })
     }
 
     fun filter(function: (V) -> Boolean): Async<Option<V>> {
-        return fold({ v ->
-                        of(v.some()
-                                   .filter(function::invoke))
+        return fold({ vStream ->
+                        succeeded(vStream.map { v ->
+                            v.some()
+                                    .filter(function::invoke)
+                        })
                     }, { thr ->
-                        ofError(thr)
+                        errored(thr)
                     }, { deferredValue ->
                         when (deferredValue) {
                             is CompletionStageValue -> {
-                                fromCompletionStage(deferredValue.inputStage.thenApply { v ->
-                                    v.some()
-                                            .filter(function::invoke)
+                                fromCompletionStage(deferredValue.inputStreamStage.thenApply { vStream ->
+                                    vStream.map { v ->
+                                        v.some()
+                                                .filter(function::invoke)
+                                    }
                                 })
                             }
                             is FluxValue -> {
@@ -301,29 +385,30 @@ interface Async<out V> : Iterable<V> {
     }
 
     fun filter(function: (V) -> Boolean, ifConditionNotMet: (V) -> Throwable): Async<V> {
-        return fold({ v ->
-                        v.some()
-                                .filter(function::invoke)
-                                .map { value -> of(value) }
-                                .getOrElse { ofError(ifConditionNotMet.invoke(v)) }
+        return fold({ vStream ->
+                        fromStreamOfAttempts(vStream.map { v ->
+                            v.some()
+                                    .filter(function::invoke)
+                                    .fold({ Try.failure(ifConditionNotMet.invoke(v)) }, { filteredV -> Try.success(filteredV) })
+                        })
                     }, { thr ->
-                        ofError(thr)
+                        errored(thr)
                     }, { deferredValue ->
                         when (deferredValue) {
                             is CompletionStageValue -> {
-                                fromCompletionStage(deferredValue.inputStage.thenCompose { v ->
-                                    v.some()
-                                            .filter(function::invoke)
-                                            .map { value -> CompletableFuture.completedFuture(value) }
-                                            .getOrElse { CompletableFuture<V>().apply { completeExceptionally(ifConditionNotMet.invoke(v)) } }
+                                fromCompletionStage(deferredValue.inputStreamStage.thenApply { vStream ->
+                                    vStream.map { v ->
+                                        Try.success(v)
+                                                .filter(function::invoke, ifConditionNotMet::invoke)
+                                                .orElseThrow()
+                                    }
                                 })
                             }
                             is FluxValue -> {
                                 fromFlux(deferredValue.inputFlux.flatMap { v ->
-                                    v.some()
-                                            .filter(function::invoke)
-                                            .map { value -> Mono.just(value) }
-                                            .getOrElse { Mono.error(ifConditionNotMet.invoke(v)) }
+                                    Try.success(v)
+                                            .filter(function::invoke, ifConditionNotMet::invoke)
+                                            .fold({ s -> Flux.just(s) }, { thr -> Flux.error(thr) })
                                 })
                             }
                         }
@@ -331,68 +416,119 @@ interface Async<out V> : Iterable<V> {
     }
 
     fun <A, R> zip(other: Async<A>, combiner: (V, A) -> R): Async<R> {
-        return fold({ v ->
-                        other.fold({ a ->
-                                       of(combiner.invoke(v, a))
+        return fold({ vStream ->
+                        other.fold({ aStream ->
+                                       fromStreamAttempt(Try.attempt({
+                                                                         vStream.asSequence()
+                                                                                 .zip(aStream.asSequence(), combiner::invoke)
+                                                                     })
+                                                                 .map { seq ->
+                                                                     seq.asStream()
+                                                                 })
                                    }, { thr ->
-                                       ofError(thr)
+                                       errored(thr)
                                    }, { defVal ->
                                        when (defVal) {
                                            is CompletionStageValue -> {
-                                               fromCompletionStage(defVal.inputStage.thenCombine(CompletableFuture.completedFuture(v)) { aVal, vVal ->
-                                                   combiner.invoke(vVal, aVal)
+                                               fromCompletionStage(defVal.inputStreamStage.thenCombine(CompletableFuture.completedFuture(vStream)) { aValStream, vValStream ->
+                                                   vValStream.asSequence()
+                                                           .zip(aValStream.asSequence(), combiner::invoke)
+                                                           .asStream()
                                                })
                                            }
                                            is FluxValue -> {
-                                               fromFlux(defVal.inputFlux.map { a -> combiner.invoke(v, a) })
+                                               fromFlux(Flux.fromStream(vStream)
+                                                                .zipWith(defVal.inputFlux, combiner::invoke))
                                            }
                                        }
                                    })
                     }, { thr ->
-                        ofError(thr)
+                        errored(thr)
                     }, { deferredValue ->
                         when (deferredValue) {
                             is CompletionStageValue -> {
-                                fromCompletionStage(deferredValue.inputStage.thenCombine(other.fold({ v ->
-                                                                                                        CompletableFuture.completedFuture(v)
-                                                                                                    }, { thr ->
-                                                                                                        CompletableFuture<A>().apply {
-                                                                                                            completeExceptionally(thr)
-                                                                                                        }
-                                                                                                    }, { defVal ->
-                                                                                                        when (defVal) {
-                                                                                                            is CompletionStageValue -> defVal.inputStage
-                                                                                                            is FluxValue -> defVal.inputFlux.next()
-                                                                                                                    .toFuture()
-                                                                                                        }
-                                                                                                    })) { vVal, aVal ->
-                                    combiner.invoke(vVal, aVal)
-                                })
+                                if (!(other is AsyncFactory.AsyncDeferredValue<*> && other.deferredValue is FluxValue<*>)) {
+                                    fromCompletionStage(deferredValue.inputStreamStage.thenCombine(other.toCompletionStage()) { vVal, aVal ->
+                                        vVal.asSequence()
+                                                .zip(aVal.asSequence(), combiner::invoke)
+                                                .asStream()
+                                    })
+                                } else {
+                                    fromFlux(Mono.fromCompletionStage(deferredValue.inputStreamStage)
+                                                     .flatMapMany { stream -> Flux.fromStream(stream) }
+                                                     .zipWith(other.toFlux(), combiner::invoke))
+                                }
                             }
                             is FluxValue -> {
-                                fromFlux(deferredValue.inputFlux.zipWith(other.fold({ v ->
-                                                                                        Mono.just(v)
-                                                                                                .flux()
-                                                                                    }, { thr -> Flux.error(thr) }, { defVal ->
-                                                                                        when (defVal) {
-                                                                                            is CompletionStageValue -> Mono.fromCompletionStage(defVal.inputStage)
-                                                                                                    .flux()
-                                                                                            is FluxValue -> defVal.inputFlux
-                                                                                        }
-                                                                                    })) { vVal, aVal -> combiner.invoke(vVal, aVal) })
+                                fromFlux(deferredValue.inputFlux.zipWith(other.toFlux()) { vVal, aVal -> combiner.invoke(vVal, aVal) })
+                            }
+                        }
+                    })
+    }
+
+    fun <A, R> zip(executor: Executor, other: Async<A>, combiner: (V, A) -> R): Async<R> {
+        return fold({ vStream ->
+                        other.fold({ aStream ->
+                                       fromFlux(Flux.fromStream(vStream)
+                                                        .publishOn(Schedulers.fromExecutor(executor))
+                                                        .zipWith(Flux.fromStream(aStream), combiner::invoke))
+                                   }, { thr ->
+                                       errored(thr)
+                                   }, { defVal ->
+                                       when (defVal) {
+                                           is CompletionStageValue -> {
+                                               fromCompletionStage(defVal.inputStreamStage.thenCombineAsync(CompletableFuture.completedFuture(vStream),
+                                                                                                            { aValStream, vValStream ->
+                                                                                                                vValStream.asSequence()
+                                                                                                                        .zip(aValStream.asSequence(),
+                                                                                                                             combiner::invoke)
+                                                                                                                        .asStream()
+                                                                                                            },
+                                                                                                            executor))
+                                           }
+                                           is FluxValue -> {
+                                               fromFlux(Flux.fromStream(vStream)
+                                                                .publishOn(Schedulers.fromExecutor(executor))
+                                                                .zipWith(defVal.inputFlux, combiner::invoke))
+                                           }
+                                       }
+                                   })
+                    }, { thr ->
+                        errored(thr)
+                    }, { deferredValue ->
+                        when (deferredValue) {
+                            is CompletionStageValue -> {
+                                if (!(other is AsyncFactory.AsyncDeferredValue<*> && other.deferredValue is FluxValue<*>)) {
+                                    fromCompletionStage(deferredValue.inputStreamStage.thenCombineAsync(other.toCompletionStage(), { vVal, aVal ->
+                                        vVal.asSequence()
+                                                .zip(aVal.asSequence(), combiner::invoke)
+                                                .asStream()
+                                    }, executor))
+                                } else {
+                                    fromFlux(Mono.fromCompletionStage(deferredValue.inputStreamStage)
+                                                     .publishOn(Schedulers.fromExecutor(executor))
+                                                     .flatMapMany { stream -> Flux.fromStream(stream) }
+                                                     .zipWith(other.toFlux(), combiner::invoke))
+                                }
+                            }
+                            is FluxValue -> {
+                                fromFlux(deferredValue.inputFlux.publishOn(Schedulers.fromExecutor(executor))
+                                                 .zipWith(other.toFlux(), combiner::invoke))
                             }
                         }
                     })
     }
 
     fun blockFirst(): Try<V> {
-        return fold({ v ->
-                        Try.success(v)
+        return fold({ vStream ->
+                        Try.fromOptional(vStream.findFirst())
                     }, { thr ->
                         Try.failure(thr)
                     }, { defVal ->
                         when (defVal) {
-                            is CompletionStageValue -> Try.attempt(defVal.inputStage.toCompletableFuture()::join)
+                            is CompletionStageValue -> Try.attempt(defVal.inputStreamStage.toCompletableFuture()::join)
+                                    .map { stream -> stream.findFirst() }
+                                    .flatMap { firstOpt -> Try.fromOptional(firstOpt) }
                             is FluxValue -> Try.attemptNullable(defVal.inputFlux::blockFirst) {
                                 IllegalArgumentException("no values were returned for flux subscriptions (or none that is non-null)")
                             }
@@ -401,31 +537,17 @@ interface Async<out V> : Iterable<V> {
     }
 
     fun blockFirstOption(): Option<V> {
-        return fold({ v ->
-                        v.some()
-                    }, { thr ->
-                        None
-                    }, { defVal ->
-                        when (defVal) {
-                            is CompletionStageValue -> Try.attempt(defVal.inputStage.toCompletableFuture()::join)
-                                    .getSuccess()
-                            is FluxValue -> Try.attemptNullable(defVal.inputFlux::blockFirst) {
-                                IllegalArgumentException("no values were returned for flux subscriptions (or none that is non-null)")
-                            }
-                                    .getSuccess()
-                        }
-                    })
+        return blockFirst().getSuccess()
     }
 
     fun block(): Try<Stream<out V>> {
-        return fold({ v ->
-                        Try.success(Stream.of(v))
+        return fold({ vStream ->
+                        Try.success(vStream)
                     }, { thr ->
                         Try.failure(thr)
                     }, { defVal ->
                         when (defVal) {
-                            is CompletionStageValue -> Try.attempt(defVal.inputStage.toCompletableFuture()::join)
-                                    .map { v -> Stream.of(v) }
+                            is CompletionStageValue -> Try.attempt(defVal.inputStreamStage.toCompletableFuture()::join)
                             is FluxValue -> Try.attemptNullable(defVal.inputFlux::toStream) {
                                 IllegalArgumentException("no stream of values was returned for flux subscriptions (or none that is non-null)")
                             }
@@ -433,36 +555,83 @@ interface Async<out V> : Iterable<V> {
                     })
     }
 
+    fun blockLast(): Try<V> {
+        return fold({ vStream ->
+                        Try.fromOptional(vStream.findFirst()) { nse -> nse }
+                    }, { thr ->
+                        Try.failure(thr)
+                    }, { defVal ->
+                        when (defVal) {
+                            is CompletionStageValue -> Try.attempt(defVal.inputStreamStage.toCompletableFuture()::join)
+                                    .flatMap { strm -> Try.fromOptional(strm.findFirst()) }
+                            is FluxValue -> Try.attemptNullable(defVal.inputFlux::blockLast) {
+                                NoSuchElementException("no stream of values was returned for flux subscriptions (or none that is non-null)")
+                            }
+                        }
+                    })
+    }
+
+    fun blockLastOption(): Option<V> {
+        return fold({ vStream ->
+                        Try.attempt { vStream.collect(Collectors.toList()) }
+                                .map { list ->
+                                    list.takeLast(1)
+                                            .stream()
+                                            .findFirst()
+                                }
+                                .flatMap { rOpt -> Try.fromOptional(rOpt) }
+                                .getSuccess()
+                    }, {
+                        None
+                    }, { defVal ->
+                        when (defVal) {
+                            is CompletionStageValue -> Try.attempt(defVal.inputStreamStage.toCompletableFuture()::join)
+                                    .map { stream -> stream.collect(Collectors.toList()) }
+                                    .map { list ->
+                                        list.takeLast(1)
+                                                .stream()
+                                                .findFirst()
+                                    }
+                                    .flatMap { lastOptional -> Try.fromOptional(lastOptional) }
+                                    .getSuccess()
+                            is FluxValue -> Try.attemptNullable(defVal.inputFlux::blockLast) {
+                                IllegalArgumentException("no stream of values was returned for flux subscriptions (or none that is non-null)")
+                            }
+                                    .getSuccess()
+                        }
+                    })
+    }
+
     fun toFlux(): Flux<out V> {
-        return fold({ v ->
-                        Mono.just(v)
-                                .flux()
+        return fold({ vStream ->
+                        Flux.fromStream(vStream)
                     }, { thr ->
                         Flux.error(thr)
                     }, { defVal ->
                         when (defVal) {
-                            is CompletionStageValue -> Mono.fromCompletionStage(defVal.inputStage)
-                                    .flux()
+                            is CompletionStageValue -> Mono.fromCompletionStage(defVal.inputStreamStage)
+                                    .flatMapMany { s -> Flux.fromStream(s) }
                             is FluxValue -> defVal.inputFlux
                         }
                     })
     }
 
-    fun toFuture(): CompletionStage<out V> {
-        return fold({ v ->
-                        CompletableFuture.completedFuture(v)
+    fun toCompletionStage(): CompletionStage<out Stream<out V>> {
+        return fold({ vStream ->
+                        CompletableFuture.completedFuture(vStream)
                     }, { thr ->
-                        CompletableFuture<V>().apply { completeExceptionally(thr) }
+                        CompletableFuture<Stream<out V>>().apply { completeExceptionally(thr) }
                     }, { defVal ->
                         when (defVal) {
-                            is CompletionStageValue -> defVal.inputStage
-                            is FluxValue -> defVal.inputFlux.next()
+                            is CompletionStageValue -> defVal.inputStreamStage // use of Flux#toStream would be a blocking operation
+                            is FluxValue -> defVal.inputFlux.collectList()
                                     .toFuture()
+                                    .thenApply { vList -> vList.stream() }
                         }
                     })
     }
 
-    fun <R> fold(completedSuccessHandler: (V) -> R, completedFailureHandler: (Throwable) -> R, deferredValueHandler: (DeferredValue<V>) -> R): R
+    fun <R> fold(succeededHandler: (Stream<out V>) -> R, erroredHandler: (Throwable) -> R, deferredHandler: (DeferredValue<V>) -> R): R
 
 
 }

--- a/funcify-kotlin-core/src/main/kotlin/funcify/container/async/AsyncFactory.kt
+++ b/funcify-kotlin-core/src/main/kotlin/funcify/container/async/AsyncFactory.kt
@@ -2,6 +2,7 @@ package funcify.container.async
 
 import reactor.core.publisher.Flux
 import java.util.concurrent.CompletionStage
+import java.util.stream.Stream
 
 
 /**
@@ -13,37 +14,37 @@ object AsyncFactory {
 
     sealed class DeferredValue<out V> {
 
-        data class CompletionStageValue<V>(val inputStage: CompletionStage<V>) : DeferredValue<V>()
+        data class CompletionStageValue<V>(val inputStreamStage: CompletionStage<Stream<out V>>) : DeferredValue<V>()
 
         data class FluxValue<V>(val inputFlux: Flux<V>) : DeferredValue<V>()
     }
 
-    data class AsyncCompletedSuccess<V>(val value: V) : Async<V> {
+    data class AsyncCompletedSuccess<V>(val valueStream: Stream<out V>) : Async<V> {
 
-        override fun <R> fold(completedSuccessHandler: (V) -> R,
-                              completedFailureHandler: (Throwable) -> R,
-                              deferredValueHandler: (DeferredValue<V>) -> R): R {
-            return completedSuccessHandler.invoke(value)
+        override fun <R> fold(succeededHandler: (Stream<out V>) -> R,
+                              erroredHandler: (Throwable) -> R,
+                              deferredHandler: (DeferredValue<V>) -> R): R {
+            return succeededHandler.invoke(valueStream)
         }
 
     }
 
     data class AsyncCompletedFailure<V>(val throwable: Throwable) : Async<V> {
 
-        override fun <R> fold(completedSuccessHandler: (V) -> R,
-                              completedFailureHandler: (Throwable) -> R,
-                              deferredValueHandler: (DeferredValue<V>) -> R): R {
-            return completedFailureHandler.invoke(throwable)
+        override fun <R> fold(succeededHandler: (Stream<out V>) -> R,
+                              erroredHandler: (Throwable) -> R,
+                              deferredHandler: (DeferredValue<V>) -> R): R {
+            return erroredHandler.invoke(throwable)
         }
 
     }
 
     data class AsyncDeferredValue<V>(val deferredValue: DeferredValue<V>) : Async<V> {
 
-        override fun <R> fold(completedSuccessHandler: (V) -> R,
-                              completedFailureHandler: (Throwable) -> R,
-                              deferredValueHandler: (DeferredValue<V>) -> R): R {
-            return deferredValueHandler.invoke(deferredValue)
+        override fun <R> fold(succeededHandler: (Stream<out V>) -> R,
+                              erroredHandler: (Throwable) -> R,
+                              deferredHandler: (DeferredValue<V>) -> R): R {
+            return deferredHandler.invoke(deferredValue)
         }
 
     }

--- a/funcify-kotlin-core/src/main/kotlin/funcify/container/attempt/TryFactory.kt
+++ b/funcify-kotlin-core/src/main/kotlin/funcify/container/attempt/TryFactory.kt
@@ -1,6 +1,5 @@
 package funcify.container.attempt
 
-
 /**
  *
  * @author smccarron


### PR DESCRIPTION
…pletionstage case avoiding the need for different flatMap methods and single value vs multiple value handling and for its built-in support for parallelism over kotllin sequences